### PR TITLE
Add Catalyst N1 and N2 neuromorphic processor papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ If you own or find some overlooked SNN papers, you can add them to this document
 
 **AAAI, ICLR**
 
+**Preprint**
+- Catalyst N1: A 131K-Neuron Open Neuromorphic Processor (**Zenodo 2026**). [[paper](https://doi.org/10.5281/zenodo.18727094)] [[code](https://github.com/catalyst-neuromorphic/catalyst-neurocore)]
+- Catalyst N2: Full Loihi 2 Feature Parity in an Open Neuromorphic Processor (**Zenodo 2026**). [[paper](https://doi.org/10.5281/zenodo.18728256)] [[code](https://github.com/catalyst-neuromorphic/catalyst-neurocore)] [[benchmarks](https://github.com/catalyst-neuromorphic/catalyst-benchmarks)]
+
 
 
 ### 2025


### PR DESCRIPTION
## Summary

Adds two 2026 preprint papers on the Catalyst open neuromorphic processor to the 2026 section:

- **Catalyst N1**: A 131K-neuron, 128-core open neuromorphic processor implemented on FPGA (Xilinx VU47P). Benchmarks: SHD 90.7%, N-MNIST 99.2%.
- **Catalyst N2**: Achieves full Loihi 2 feature parity in an open neuromorphic processor. Benchmarks: SSC 72.1%, GSC KWS 88.0%.

Both papers include links to the open-source code repository and benchmark suite.

- Papers: [N1 DOI](https://doi.org/10.5281/zenodo.18727094), [N2 DOI](https://doi.org/10.5281/zenodo.18728256)
- Code: [catalyst-neurocore](https://github.com/catalyst-neuromorphic/catalyst-neurocore)
- Benchmarks: [catalyst-benchmarks](https://github.com/catalyst-neuromorphic/catalyst-benchmarks)
- Website: [catalyst-neuromorphic.com](https://catalyst-neuromorphic.com)